### PR TITLE
Add param in timebased() to treat numeric with only a few values as c…

### DIFF
--- a/R/timebased.R
+++ b/R/timebased.R
@@ -88,7 +88,7 @@ timebased <- function(data_analyze, date_variable, time_unit="auto",
       resVars=c(resVars,varName)
 
       if(var$type %in% c('Numeric','Integer') &
-         length(unique(data_analyze[[varName]]))>nvals_num_to_cat){
+         var$qDistinct > nvals_num_to_cat){
         # Box plot for visualizing difference in distribution among time
 
         varAnalyze = data.frame(dat=as.double(data_analyze[[varName]]), date=as.factor(dateData))

--- a/R/timebased.R
+++ b/R/timebased.R
@@ -3,6 +3,7 @@
 #' @param data_analyze a data frame to analyze
 #' @param date_variable the variable (length one character vector or bare expression) that will be used to pivot all other variables
 #' @param time_unit the time unit to use if not automatically
+#' @param nvals_num_to_cat numeric numeric values with this many or fewer distinct values will be treated as categorical
 #' @param outdir an optional output directory to save the resulting plots as png images
 #'
 #' @examples
@@ -19,7 +20,8 @@
 #' @importFrom stats quantile
 #' @importFrom stats setNames
 #'
-timebased <- function(data_analyze, date_variable, time_unit="auto", outdir) {
+timebased <- function(data_analyze, date_variable, time_unit="auto",
+                      nvals_num_to_cat=2,outdir) {
 
   # Obtain metadata for the dataset
   varMetadata = suppressWarnings(anomalies(data_analyze)$variables)
@@ -85,7 +87,8 @@ timebased <- function(data_analyze, date_variable, time_unit="auto", outdir) {
     }else{
       resVars=c(resVars,varName)
 
-      if(var$type %in% c('Integer', 'Numeric')){
+      if(var$type %in% c('Numeric','Integer') &
+         length(unique(data_analyze[[varName]]))>nvals_num_to_cat){
         # Box plot for visualizing difference in distribution among time
 
         varAnalyze = data.frame(dat=as.double(data_analyze[[varName]]), date=as.factor(dateData))

--- a/R/timebased.R
+++ b/R/timebased.R
@@ -94,12 +94,13 @@ timebased <- function(data_analyze, date_variable, time_unit="auto",
         varAnalyze = data.frame(dat=as.double(data_analyze[[varName]]), date=as.factor(dateData))
 
         ylim1 = boxplot.stats(varAnalyze$dat)$stats[c(1, 5)]
+        yrange = ylim1[2]-ylim1[1]
 
         ggplot(varAnalyze, aes(date, dat)) +
           geom_boxplot(fill='#ccccff', outlier.color = 'red', outlier.shape=1, na.rm=TRUE) +
           theme_minimal() +
           labs(x = varName, y = "Rows") +
-          coord_cartesian(ylim = ylim1*1.1) +
+          coord_cartesian(ylim = ylim1+c(-0.1*yrange,0.1*yrange)) +
           ggtitle(paste("Histogram of", var$Variable)) +
           theme(axis.text.x = element_text(angle = 45, hjust = 1))
 

--- a/man/timebased.Rd
+++ b/man/timebased.Rd
@@ -4,7 +4,8 @@
 \alias{timebased}
 \title{Analyze each variable in respect to a time variable}
 \usage{
-timebased(data_analyze, date_variable, time_unit = "auto", outdir)
+timebased(data_analyze, date_variable, time_unit = "auto",
+  nvals_num_to_cat = 2, outdir)
 }
 \arguments{
 \item{data_analyze}{a data frame to analyze}
@@ -12,6 +13,8 @@ timebased(data_analyze, date_variable, time_unit = "auto", outdir)
 \item{date_variable}{the variable (length one character vector or bare expression) that will be used to pivot all other variables}
 
 \item{time_unit}{the time unit to use if not automatically}
+
+\item{nvals_num_to_cat}{numeric numeric values with this many or fewer distinct values will be treated as categorical}
 
 \item{outdir}{an optional output directory to save the resulting plots as png images}
 }


### PR DESCRIPTION
timebased() previously treated numeric variables with few values (0/1 for example) like continuous variables.  The plots looked radically different for a 65/35 split between these values and an 80/20 split.  If these types of variables are treated as categorical, the plots make more visual sense.  I set the default number of distinct values below which a variable is treated as categorical as 2.  That covers the 0/1 case.